### PR TITLE
fix: fix certification section to sho on mobile. Remove <div> around …

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import "./components/skills/SkillsSection.scss";
 import ResumeLayout from "./components/ResumeLayout";
-import ProfileSection from "./components/ProfileSection";
+import ProfileSection from "./components/profile/ProfileSection";
 import ExperienceSection from "./components/ExperienceSection";
 import EducationSection from "./components/EducationSection";
 import SkillsSection from "./components/skills/SkillsSection";
@@ -22,17 +22,24 @@ function App() {
       left={
         <>
           <ProfileSection profile={profile} />
-          <div className="resume-skills-mobile skills">
-            <SkillsSection skills={skills} />
-          </div>
+          <Certifications
+            certifications={certifications}
+            display="resume-skills-mobile"
+          />
+          {/* <div className="resume-skills-mobile skills"> */}
+          <SkillsSection skills={skills} display="resume-skills-mobile" />
+          {/* </div> */}
           <ExperienceSection experiences={experiences} />
           <EducationSection education={education} />
         </>
       }
       right={
         <div className={"skills-desktop skills"}>
-          <SkillsSection skills={skills} />
-          <Certifications certifications={certifications} />
+          <SkillsSection skills={skills} display="skills-desktop" />
+          <Certifications
+            certifications={certifications}
+            display="skills-desktop"
+          />
         </div>
       }
     />

--- a/src/App.js
+++ b/src/App.js
@@ -26,21 +26,19 @@ function App() {
             certifications={certifications}
             display="resume-skills-mobile"
           />
-          {/* <div className="resume-skills-mobile skills"> */}
           <SkillsSection skills={skills} display="resume-skills-mobile" />
-          {/* </div> */}
           <ExperienceSection experiences={experiences} />
           <EducationSection education={education} />
         </>
       }
       right={
-        <div className={"skills-desktop skills"}>
+        <>
           <SkillsSection skills={skills} display="skills-desktop" />
           <Certifications
             certifications={certifications}
             display="skills-desktop"
           />
-        </div>
+        </>
       }
     />
   );

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,3 +1,9 @@
 $breakpoint-mobile: 700px;
 $breakpoint-tablet: 900px;
 $breakpoint-desktop: 1200px;
+
+// Colours
+$text-background: white;
+$background-lightgrey: #f7f7f7;
+$background-darkgrey: #e9ecef;
+$background-darkergrey: #8197ae;

--- a/src/components/Certifications.js
+++ b/src/components/Certifications.js
@@ -1,7 +1,7 @@
 import React from "react";
 
-const Certifications = ({ certifications }) => (
-  <section>
+const Certifications = ({ certifications, display }) => (
+  <section className={`${display}`}>
     <h2>Certifications</h2>
     <ul>
       {certifications.map((certification, idx) => (

--- a/src/components/Experience.scss
+++ b/src/components/Experience.scss
@@ -6,4 +6,5 @@ ul.experience-details {
 
 .experience-details li {
   padding: 0em 1rem;
+  border: none;
 }

--- a/src/components/ResumeLayout.scss
+++ b/src/components/ResumeLayout.scss
@@ -1,5 +1,9 @@
 @use "../_variables.scss" as v;
 
+section + section {
+  border-top: #22223b 2px solid;
+}
+
 .resume-layout {
   max-width: 1000px;
   margin: 40px auto;
@@ -35,7 +39,7 @@
 .resume-main {
   flex: 2;
   padding: 40px 32px;
-  background-color: azure;
+  // background-color: v.$background-darkergrey;
 }
 .resume-side {
   flex: 1;
@@ -58,8 +62,11 @@ ul {
 }
 
 li {
-  background-color: white;
+  background-color: v.$text-background;
   border-radius: 6px;
+  // border-color: #22223b;
+  // border-style: solid;
+  // border-width: 1px;
   padding: 0.8rem;
 }
 

--- a/src/components/profile/ProfileSection.js
+++ b/src/components/profile/ProfileSection.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 const ProfileSection = ({ profile }) => (
-  <section>
+  <section className="profile-section">
     <h2>Profile</h2>
     <p>{profile}</p>
   </section>

--- a/src/components/skills/SkillsSection.js
+++ b/src/components/skills/SkillsSection.js
@@ -1,8 +1,8 @@
 import React from "react";
 import "./SkillsSection.scss";
 
-const SkillsSection = ({ skills }) => (
-  <section className="skills">
+const SkillsSection = ({ skills, display }) => (
+  <section className={`skills ${display}`}>
     <div className="skills-flex">
       <h2>Skills</h2>
       <ul>

--- a/src/components/skills/SkillsSection.scss
+++ b/src/components/skills/SkillsSection.scss
@@ -1,7 +1,7 @@
 @use "../../_variables.scss" as v;
 
 .skills {
-  background: #f7f7f7;
+  background: v.$background-lightgrey;
 }
 
 .skills-flex {
@@ -9,6 +9,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 24px;
+  padding-bottom: 1rem;
 }
 
 .skills-flex h2 {
@@ -28,7 +29,7 @@
 }
 
 .skills-flex li {
-  background: #e9ecef;
+  background: v.$background-darkgrey;
   border-radius: 6px;
   padding: 6px 14px;
   font-size: 1rem;


### PR DESCRIPTION
…sections

- fix an issue where certifications did not show on narrow screens
- added line above section elements, apart from the first one
- add colours into vars
- remove the _div_ element within {left} and {right} blocks around the Skills section