### PR TITLE
Fix/header vibrations

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -13,29 +13,10 @@ const sections = [
 ];
 
 function NavBar() {
-  const [open, setOpen] = useState(false);
-
-  // const handleNavClick = (anchor) => {
-  //   const el = document.getElementById(anchor);
-  //   if (el) {
-  //     el.scrollIntoView({ behavior: "smooth" });
-  //     el.classList.add("zoom-animate");
-  //     setTimeout(() => {
-  //       el.classList.remove("zoom-animate");
-  //     }, 500); // match animation duration
-  //     setOpen(false);
-  //   }
-  // };
+  const [open] = useState(false);
 
   return (
     <nav className="navbar">
-      <button
-        className="navbar-toggle"
-        onClick={() => setOpen((prev) => !prev)}
-        aria-label="Toggle navigation"
-      >
-        ☰
-      </button>
       <ul className={`navbar-list${open ? " open" : ""}`}>
         {sections.map((section) => (
           <li key={section.anchor}>

--- a/src/components/NavBar.scss
+++ b/src/components/NavBar.scss
@@ -10,14 +10,14 @@
   z-index: 10;
 }
 
-.navbar-toggle {
-  display: none;
-  background: none;
-  border: none;
-  font-size: 2rem;
-  margin: 0.5rem 1rem;
-  cursor: pointer;
-}
+// .navbar-toggle {
+//   display: none;
+//   background: none;
+//   border: none;
+//   font-size: 2rem;
+//   margin: 0.5rem 1rem;
+//   cursor: pointer;
+// }
 
 .navbar-list {
   display: flex;
@@ -58,4 +58,18 @@
 
 .navbar-link:hover {
   background: #d12828;
+}
+
+// When scrolling down, trigger opacity for navbar
+.fade-out {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+.fade-in {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
 }

--- a/src/components/NavBar.scss
+++ b/src/components/NavBar.scss
@@ -40,36 +40,12 @@
   align-items: stretch;
 }
 
-// .navbar-link {
-//   width: 100%;
-//   text-align: center;
-// }
-
-// .navbar-link {
-//   background: none;
-//   border: none;
-//   font-size: 1rem;
-//   color: #333;
-//   cursor: pointer;
-//   padding: 0.5rem 1rem;
-//   border-radius: 4px;
-//   transition: background 0.2s;
-// }
-
 .navbar-link:hover {
   background: #d12828;
 }
 
-// When scrolling down, trigger opacity for navbar
-.fade-out {
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
-}
-.fade-in {
-  opacity: 1;
-  visibility: visible;
-  pointer-events: auto;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
+@media screen and (max-width: v.$breakpoint-mobile) {
+  .navbar {
+    display: none; // Hide navbar on mobile - button to be shown in header
+  }
 }

--- a/src/components/ResumeLayout.js
+++ b/src/components/ResumeLayout.js
@@ -1,4 +1,4 @@
-import React, { use, useEffect, useRef, useState } from "react";
+import React, { useRef } from "react";
 import { useResponsiveHeaderShrink } from "./skills/hooks/useResponsiveHeaderShrink";
 import "./ResumeLayout.scss";
 import NavBar from "./NavBar";
@@ -14,7 +14,7 @@ const navSections = [
 const ResumeLayout = ({ left, right, skills, personalInfo }) => {
   const headerRef = useRef(null);
 
-  const { isShrunk, showHamburger, menuOpen, setMenuOpen } =
+  const { showHamburger, menuOpen, setMenuOpen } =
     useResponsiveHeaderShrink(headerRef);
 
   const handleMenuClick = (anchor) => {

--- a/src/components/ResumeLayout.js
+++ b/src/components/ResumeLayout.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { use, useEffect, useRef, useState } from "react";
+import { useResponsiveHeaderShrink } from "./skills/hooks/useResponsiveHeaderShrink";
 import "./ResumeLayout.scss";
 import NavBar from "./NavBar";
 
@@ -12,41 +13,9 @@ const navSections = [
 
 const ResumeLayout = ({ left, right, skills, personalInfo }) => {
   const headerRef = useRef(null);
-  const [showHamburger, setShowHamburger] = useState(
-    () => window.innerWidth <= 700
-  );
-  const [menuOpen, setMenuOpen] = useState(false);
 
-  useEffect(() => {
-    const handleScroll = () => {
-      if (!headerRef.current) return;
-      if (window.scrollY > 30 || window.innerWidth <= 700) {
-        headerRef.current.classList.add("shrink");
-        setShowHamburger(true);
-      } else {
-        headerRef.current.classList.remove("shrink");
-        setShowHamburger(false);
-        setMenuOpen(false);
-      }
-    };
-    window.addEventListener("scroll", handleScroll);
-    // window.addEventListener("resize", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  // For mobile: always show hamburger, never NavBar
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth <= 700) {
-        setShowHamburger(true);
-      } else if (window.scrollY <= 30) {
-        setShowHamburger(false);
-      }
-    };
-    window.addEventListener("resize", handleResize);
-    handleResize();
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
+  const { isShrunk, showHamburger, menuOpen, setMenuOpen } =
+    useResponsiveHeaderShrink(headerRef);
 
   const handleMenuClick = (anchor) => {
     const el = document.getElementById(anchor);
@@ -95,6 +64,7 @@ const ResumeLayout = ({ left, right, skills, personalInfo }) => {
           <h2 className="resume-title">{personalInfo.jobTitle}</h2>
         </section>
       </header>
+      {/* <div style={{ height: isShrunk ? "100px" : "100px" }}></div> */}
       {/* Hide NavBar if hamburger is shown */}
       {!showHamburger && <NavBar />}
       <div className="resume-content">

--- a/src/components/ResumeLayout.js
+++ b/src/components/ResumeLayout.js
@@ -66,8 +66,8 @@ const ResumeLayout = ({ left, right, skills, personalInfo }) => {
       </header>
       {/* <div style={{ height: isShrunk ? "100px" : "100px" }}></div> */}
       {/* Hide NavBar if hamburger is shown */}
-      {!showHamburger && <NavBar />}
-      {/* <NavBar /> */}
+      {/* {!showHamburger && <NavBar />} */}
+      <NavBar />
       <div className="resume-content">
         <div className="resume-main">{left}</div>
         <div className="resume-side skills">{right}</div>

--- a/src/components/ResumeLayout.js
+++ b/src/components/ResumeLayout.js
@@ -67,6 +67,7 @@ const ResumeLayout = ({ left, right, skills, personalInfo }) => {
       {/* <div style={{ height: isShrunk ? "100px" : "100px" }}></div> */}
       {/* Hide NavBar if hamburger is shown */}
       {!showHamburger && <NavBar />}
+      {/* <NavBar /> */}
       <div className="resume-content">
         <div className="resume-main">{left}</div>
         <div className="resume-side skills">{right}</div>

--- a/src/components/ResumeLayout.scss
+++ b/src/components/ResumeLayout.scss
@@ -20,10 +20,13 @@ section + section {
   text-align: center;
   border-radius: 1em;
   display: flex;
+  transition: padding 0.3s ease, box-shadow 0.3s ease;
+  will-change: padding, font-size; // Tells the browser to optimize for these properties
 }
 
 .resume-header.shrink {
   padding: 12px 12px 8px 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
 }
 
 .resume-header .resume-name,
@@ -127,6 +130,7 @@ section + section {
   background: v.$background-header;
   color: #fff;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .resume-name {
@@ -142,13 +146,29 @@ section + section {
   letter-spacing: 0.5px;
 }
 
-@media (min-width: v.$breakpoint-mobile) {
+.resume-name,
+.resume-title {
+  transition: font-size 0.3s ease, line-height 0.3s ease;
+}
+
+/* @media (min-width: v.$breakpoint-mobile) {
   .resume-header.shrink .resume-header-main > .resume-name {
     font-size: 2rem;
   }
   .resume-header.shrink .resume-header-main > .resume-title {
     font-size: 1.1rem;
   }
+} */
+
+// instead of using @medida query, the size reduction is handled by the useResponsiveHeaderShrink hook
+.resume-header.shrink .resume-name {
+  font-size: 2rem;
+  line-height: 1.2;
+}
+
+.resume-header.shrink .resume-title {
+  font-size: 1.1rem;
+  line-height: 1.2;
 }
 
 .resume-content {

--- a/src/components/skills/hooks/useResponsiveHeaderShrink.js
+++ b/src/components/skills/hooks/useResponsiveHeaderShrink.js
@@ -15,8 +15,8 @@ export const useResponsiveHeaderShrink = (headerRef) => {
   );
   console.log("body height:", document.body.offsetHeight);
   useEffect(() => {
-    const SHRINK_THRESHOLD = 30;
-    const UNSHRINK_THRESHOLD = 70;
+    const SHRINK_THRESHOLD = 60;
+    const UNSHRINK_THRESHOLD = 5;
 
     const handleUpdate = () => {
       if (!headerRef.current) return;

--- a/src/components/skills/hooks/useResponsiveHeaderShrink.js
+++ b/src/components/skills/hooks/useResponsiveHeaderShrink.js
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from "react";
+
+export const useResponsiveHeaderShrink = (headerRef) => {
+  const [isShrunk, setIsShrunk] = useState(false);
+  const [showHamburger, setShowHamburger] = useState(
+    () => window.innerWidth <= 700
+  );
+  const [menuOpen, setMenuOpen] = useState(false);
+  const isShrunkRef = useRef(false);
+
+  console.log("scrollY:", window.scrollY);
+  console.log(
+    "header height:",
+    headerRef.current ? headerRef.current.offsetHeight : "null"
+  );
+  console.log("body height:", document.body.offsetHeight);
+  useEffect(() => {
+    const SHRINK_THRESHOLD = 30;
+    const UNSHRINK_THRESHOLD = 70;
+
+    const handleUpdate = () => {
+      if (!headerRef.current) return;
+
+      const scrollY = window.scrollY;
+      const isMobile = window.innerWidth <= 700;
+
+      // if (scrollY < 70) return;
+
+      if ((scrollY > SHRINK_THRESHOLD || isMobile) && !isShrunkRef.current) {
+        headerRef.current.classList.add("shrink");
+        setShowHamburger(true);
+        setIsShrunk(true);
+        isShrunkRef.current = true;
+      } else if (
+        scrollY < UNSHRINK_THRESHOLD &&
+        isShrunkRef.current &&
+        !isMobile
+      ) {
+        headerRef.current.classList.remove("shrink");
+        setShowHamburger(false);
+        setMenuOpen(false);
+        setIsShrunk(false);
+        isShrunkRef.current = false;
+      }
+    };
+
+    window.addEventListener("scroll", handleUpdate);
+    window.addEventListener("resize", handleUpdate);
+    handleUpdate(); // run once on mount
+
+    return () => {
+      window.removeEventListener("scroll", handleUpdate);
+      window.removeEventListener("resize", handleUpdate);
+    };
+  }, [headerRef]);
+
+  return {
+    isShrunk,
+    showHamburger,
+    menuOpen,
+    setMenuOpen,
+  };
+};


### PR DESCRIPTION
This PR resolve issue #21  by:

1. changing values of scrollY that trigger header shrink (form 30 to 60) and unshrink (was 70, now 5). This allows headroom to avoid bouncing effect.
2. Making the NavBar permanently present on js script (aka not conditional on _showHamburger_, and hide it on mobile display via css.